### PR TITLE
Adding system tags when creating or importing a nat gateway

### DIFF
--- a/aws-ec2-natgateway/src/main/java/software/amazon/ec2/natgateway/Configuration.java
+++ b/aws-ec2-natgateway/src/main/java/software/amazon/ec2/natgateway/Configuration.java
@@ -1,8 +1,20 @@
 package software.amazon.ec2.natgateway;
 
+import java.util.Map;
+import java.util.stream.Collectors;
+
 class Configuration extends BaseConfiguration {
 
     public Configuration() {
         super("aws-ec2-natgateway.json");
+    }
+
+    @Override
+    public Map<String, String> resourceDefinedTags(final ResourceModel model) {
+        if (model.getTags() == null) {
+            return null;
+        } else {
+            return model.getTags().stream().collect(Collectors.toMap(tag -> tag.getKey(), tag -> tag.getValue()));
+        }
     }
 }

--- a/aws-ec2-natgateway/src/main/java/software/amazon/ec2/natgateway/CreateHandler.java
+++ b/aws-ec2-natgateway/src/main/java/software/amazon/ec2/natgateway/CreateHandler.java
@@ -33,7 +33,7 @@ public class CreateHandler extends BaseHandlerStd {
             .then(progress ->
                  proxy.initiate("AWS-EC2-NatGateway::Create", proxyClient,progress.getResourceModel(),
                          progress.getCallbackContext())
-                    .translateToServiceRequest(awsRequest -> Translator.translateToCreateRequest(model, clientToken))
+                    .translateToServiceRequest(awsRequest -> Translator.translateToCreateRequest(model, request, clientToken))
                     .makeServiceCall((awsRequest, client) -> createResource(awsRequest, proxyClient, logger, model))
                     .stabilize(this::isCreateStabilized) // Only moves on when isCreateStabilized returns true
                     .progress()

--- a/aws-ec2-natgateway/src/main/java/software/amazon/ec2/natgateway/Translator.java
+++ b/aws-ec2-natgateway/src/main/java/software/amazon/ec2/natgateway/Translator.java
@@ -116,16 +116,16 @@ public class Translator {
    */
   static List<ResourceModel> translateFromListRequest(final DescribeNatGatewaysResponse describeNatGatewaysResponse) {
     return streamOfOrEmpty(describeNatGatewaysResponse.natGateways())
-            .map(resource -> ResourceModel.builder()
-                    .natGatewayId(resource.natGatewayId())
-                    .build())
-            .collect(Collectors.toList());
+        .map(resource -> ResourceModel.builder()
+            .natGatewayId(resource.natGatewayId())
+            .build())
+        .collect(Collectors.toList());
   }
 
   private static <T> Stream<T> streamOfOrEmpty(final Collection<T> collection) {
     return Optional.ofNullable(collection)
-            .map(Collection::stream)
-            .orElseGet(Stream::empty);
+        .map(Collection::stream)
+        .orElseGet(Stream::empty);
   }
 
   /**

--- a/aws-ec2-natgateway/src/main/java/software/amazon/ec2/natgateway/Translator.java
+++ b/aws-ec2-natgateway/src/main/java/software/amazon/ec2/natgateway/Translator.java
@@ -9,11 +9,14 @@ import software.amazon.awssdk.services.ec2.model.DeleteNatGatewayRequest;
 import software.amazon.awssdk.services.ec2.model.TagSpecification;
 import software.amazon.awssdk.services.ec2.model.Tag;
 import software.amazon.awssdk.services.ec2.model.NatGateway;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -32,13 +35,13 @@ public class Translator {
    * @param model resource model
    * @return awsRequest the aws service request to create a resource
    */
-  static CreateNatGatewayRequest translateToCreateRequest(final ResourceModel model, final String token) {
+  static CreateNatGatewayRequest translateToCreateRequest(final ResourceModel model, final ResourceHandlerRequest<ResourceModel> request, final String token) {
     return CreateNatGatewayRequest.builder()
             .clientToken(token)
             .subnetId(model.getSubnetId())
             .allocationId(model.getAllocationId())
             .connectivityType(model.getConnectivityType())
-            .tagSpecifications(convertNatTagsToTagSpecification(model.getTags()).orElse(null))
+            .tagSpecifications(convertNatTagsToTagSpecification(request.getDesiredResourceTags(), request.getSystemTags()).orElse(null))
             .build();
   }
 
@@ -64,7 +67,7 @@ public class Translator {
             .subnetId(natGateway.subnetId())
             .connectivityType(natGateway.connectivityTypeAsString())
             .allocationId(natGateway.natGatewayAddresses().get(0).allocationId())
-            .tags(convertToNatTags(natGateway.tags()))
+            .tags(convertToNatTags(natGateway.tags()).stream().filter(n -> !n.getKey().startsWith("aws:")).collect(Collectors.toList()))
             .build();
   }
 
@@ -83,7 +86,7 @@ public class Translator {
    * @param model resource model
    * @return awsRequest the aws service request to create the tags
    */
-  static CreateTagsRequest translateToCreateTagsRequest(final List<software.amazon.ec2.natgateway.Tag> tagsToCreate, final ResourceModel model) {
+  static CreateTagsRequest translateToCreateTagsRequest(Map<String, String> tagsToCreate, final ResourceModel model) {
     return CreateTagsRequest.builder().tags(convertToSdkTags(tagsToCreate)).resources(model.getNatGatewayId()).build();
   }
 
@@ -93,7 +96,7 @@ public class Translator {
    * @param model resource model
    * @return awsRequest the aws service request to delete the tags
    */
-  static DeleteTagsRequest translateToDeleteTagsRequest(final List<software.amazon.ec2.natgateway.Tag> tagsToDelete, final ResourceModel model) {
+  static DeleteTagsRequest translateToDeleteTagsRequest(Map<String, String> tagsToDelete, final ResourceModel model) {
     return DeleteTagsRequest.builder().tags(convertToSdkTags(tagsToDelete)).resources(model.getNatGatewayId()).build();
   }
 
@@ -113,16 +116,16 @@ public class Translator {
    */
   static List<ResourceModel> translateFromListRequest(final DescribeNatGatewaysResponse describeNatGatewaysResponse) {
     return streamOfOrEmpty(describeNatGatewaysResponse.natGateways())
-        .map(resource -> ResourceModel.builder()
-            .natGatewayId(resource.natGatewayId())
-            .build())
-        .collect(Collectors.toList());
+            .map(resource -> ResourceModel.builder()
+                    .natGatewayId(resource.natGatewayId())
+                    .build())
+            .collect(Collectors.toList());
   }
 
   private static <T> Stream<T> streamOfOrEmpty(final Collection<T> collection) {
     return Optional.ofNullable(collection)
-        .map(Collection::stream)
-        .orElseGet(Stream::empty);
+            .map(Collection::stream)
+            .orElseGet(Stream::empty);
   }
 
   /**
@@ -145,8 +148,8 @@ public class Translator {
    * @param tags List of Nat Gateway Resource tags
    * @return List of SDK tags
    */
-  static List<Tag> convertToSdkTags(final List<software.amazon.ec2.natgateway.Tag> tags) {
-    return Optional.ofNullable(tags).orElse(Collections.emptyList())
+  static List<Tag> convertToSdkTags(Map<String, String> tags) {
+    return Optional.ofNullable(tags.entrySet()).orElse(Collections.emptySet())
             .stream()
             .map(tag -> Tag.builder()
                     .key(tag.getKey())
@@ -160,13 +163,22 @@ public class Translator {
    * @param modelTags list of Nat Gateway resource tags
    * @return List of TagSpecification tags
    */
-  private static Optional<List<TagSpecification>> convertNatTagsToTagSpecification(final List<software.amazon.ec2.natgateway.Tag> modelTags) {
-    if (modelTags == null) {
+  private static Optional<List<TagSpecification>> convertNatTagsToTagSpecification(Map<String, String> modelTags, Map<String, String> systemTags) {
+    Map<String, String> allTags = new HashMap<String, String>();
+    if (modelTags == null && systemTags == null) {
       return Optional.empty();
+    }
+
+    if (modelTags != null) {
+      allTags.putAll(modelTags);
+    }
+
+    if (systemTags != null) {
+      allTags.putAll(systemTags);
     }
     return Optional.of(Arrays.asList(TagSpecification.builder()
             .resourceType("natgateway")
-            .tags(convertToSdkTags(modelTags))
+            .tags(convertToSdkTags(allTags))
             .build()));
   }
 }

--- a/aws-ec2-natgateway/src/main/java/software/amazon/ec2/natgateway/UpdateHandler.java
+++ b/aws-ec2-natgateway/src/main/java/software/amazon/ec2/natgateway/UpdateHandler.java
@@ -23,11 +23,11 @@ public class UpdateHandler extends BaseHandlerStd {
     private Logger logger;
 
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
-            final AmazonWebServicesClientProxy proxy,
-            final ResourceHandlerRequest<ResourceModel> request,
-            final CallbackContext callbackContext,
-            final ProxyClient<Ec2Client> proxyClient,
-            final Logger logger) {
+        final AmazonWebServicesClientProxy proxy,
+        final ResourceHandlerRequest<ResourceModel> request,
+        final CallbackContext callbackContext,
+        final ProxyClient<Ec2Client> proxyClient,
+        final Logger logger) {
 
         this.logger = logger;
 
@@ -83,7 +83,7 @@ public class UpdateHandler extends BaseHandlerStd {
             final CallbackContext callbackContext,
             final ResourceHandlerRequest<ResourceModel> request) {
 
-        final Map<String, String> oldTags = request.getPreviousResourceTags() == null ? Collections.emptyMap() : request.getPreviousResourceTags();;
+        final Map<String, String> oldTags = request.getPreviousResourceTags() == null ? Collections.emptyMap() : request.getPreviousResourceTags();
         final Map<String, String> newTags = request.getDesiredResourceTags() == null ? Collections.emptyMap() : request.getDesiredResourceTags();
 
         final Map<String, String> tagsToDelete = new HashMap<String, String>();

--- a/aws-ec2-natgateway/src/test/java/software/amazon/ec2/natgateway/UpdateHandlerTest.java
+++ b/aws-ec2-natgateway/src/test/java/software/amazon/ec2/natgateway/UpdateHandlerTest.java
@@ -41,6 +41,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.Map;
+import java.util.stream.Collectors;
+
 @ExtendWith(MockitoExtension.class)
 public class UpdateHandlerTest extends AbstractTestBase {
 
@@ -109,6 +112,9 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .previousResourceState(oldModel).desiredResourceState(newModel).build();
 
+        request.setPreviousResourceTags(oldModel.getTags().stream().collect(Collectors.toMap(tag -> tag.getKey(), tag -> tag.getValue())));
+        request.setDesiredResourceTags(newModel.getTags().stream().collect(Collectors.toMap(tag -> tag.getKey(), tag -> tag.getValue())));
+
         final ProgressEvent<ResourceModel, CallbackContext> response =
                 handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
@@ -141,6 +147,9 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .previousResourceState(oldModel).desiredResourceState(newModel).build();
+
+        request.setPreviousResourceTags(oldModel.getTags().stream().collect(Collectors.toMap(tag -> tag.getKey(), tag -> tag.getValue())));
+        request.setDesiredResourceTags(newModel.getTags().stream().collect(Collectors.toMap(tag -> tag.getKey(), tag -> tag.getValue())));
 
         final ProgressEvent<ResourceModel, CallbackContext> response =
                 handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
@@ -178,6 +187,9 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .previousResourceState(oldModel).desiredResourceState(newModel).build();
+
+        request.setPreviousResourceTags(oldModel.getTags().stream().collect(Collectors.toMap(tag -> tag.getKey(), tag -> tag.getValue())));
+        request.setDesiredResourceTags(newModel.getTags().stream().collect(Collectors.toMap(tag -> tag.getKey(), tag -> tag.getValue())));
 
         final ProgressEvent<ResourceModel, CallbackContext> response =
                 handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
@@ -228,6 +240,9 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .previousResourceState(oldModel).desiredResourceState(newModel).build();
 
+        request.setPreviousResourceTags(oldModel.getTags().stream().collect(Collectors.toMap(tag -> tag.getKey(), tag -> tag.getValue())));
+        request.setDesiredResourceTags(newModel.getTags().stream().collect(Collectors.toMap(tag -> tag.getKey(), tag -> tag.getValue())));
+
         Assertions.assertThrows(CfnInvalidRequestException.class, () -> {
             handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
         });
@@ -254,6 +269,9 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .previousResourceState(oldModel).desiredResourceState(newModel).build();
 
+        request.setPreviousResourceTags(oldModel.getTags().stream().collect(Collectors.toMap(tag -> tag.getKey(), tag -> tag.getValue())));
+        request.setDesiredResourceTags(newModel.getTags().stream().collect(Collectors.toMap(tag -> tag.getKey(), tag -> tag.getValue())));
+
         Assertions.assertThrows(CfnServiceLimitExceededException.class, () -> {
             handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
         });
@@ -273,6 +291,9 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .previousResourceState(oldModel).desiredResourceState(newModel).build();
+
+        request.setPreviousResourceTags(oldModel.getTags().stream().collect(Collectors.toMap(tag -> tag.getKey(), tag -> tag.getValue())));
+        request.setDesiredResourceTags(newModel.getTags().stream().collect(Collectors.toMap(tag -> tag.getKey(), tag -> tag.getValue())));
 
         final ProgressEvent<ResourceModel, CallbackContext> response =
                 handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Including System Tags in tag on create so that CloudFormation can add the "aws:cloudformation" prefix tags to the Nat Gateway resources created. Also including them in the update handler so that they can get added to imported nat gateways. Tested manually using `cfn submit --no-role --set-default`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
